### PR TITLE
Allow http for foreman in case of unattended installation

### DIFF
--- a/modules/foreman/manifests/config.pp
+++ b/modules/foreman/manifests/config.pp
@@ -75,7 +75,15 @@ class foreman::config {
       ensure    => absent;
 
     "/etc/httpd/conf.d/katello.d/foreman.conf":
-      content => template("foreman/httpd.conf.erb"),
+      content => template("foreman/foreman_https.conf.erb"),
+      owner   => $foreman::user,
+      group   => $foreman::user,
+      mode    => "600",
+      notify  => Exec["reload-apache2"],
+      before  => Class["apache2::service"];
+
+    "/etc/httpd/conf.d/foreman_http.conf":
+      content => template("foreman/foreman_http.conf.erb"),
       owner   => $foreman::user,
       group   => $foreman::user,
       mode    => "600",

--- a/modules/foreman/templates/foreman_http.conf.erb
+++ b/modules/foreman/templates/foreman_http.conf.erb
@@ -1,0 +1,19 @@
+<Proxy balancer://foreman-thin-unattended-servers>
+  <%- scope.lookupvar("foreman::thin_process_count").to_i.times do |i| -%>
+    <%= "BalancerMember http://127.0.0.1:#{scope.lookupvar('foreman::thin_start_port').to_i + i}/#{scope.lookupvar('foreman::deployment_url')}/unattended" %>
+  <%- end -%>
+</Proxy>
+
+# Allow http for unattended path (for anaconda etc.)
+<Location /foreman/unattended>
+  ProxyPass balancer://foreman-thin-unattended-servers
+  ProxyPassReverse balancer://foreman-thin-unattended-servers
+</Location>
+
+# Redirecto to https version otherwise
+<LocationMatch /foreman(?!/unattended)>
+  RewriteEngine On
+  RewriteCond %{HTTPS} off
+  RewriteRule /(.*)$ https://%{HTTP_HOST}%{REQUEST_URI}
+</LocationMatch>
+

--- a/modules/foreman/templates/foreman_https.conf.erb
+++ b/modules/foreman/templates/foreman_https.conf.erb
@@ -1,4 +1,4 @@
-<Proxy balancer://foremanthinservers>
+<Proxy balancer://foreman-thin-servers>
   <%- scope.lookupvar("foreman::thin_process_count").to_i.times do |i| -%>
     <%= "BalancerMember http://127.0.0.1:#{scope.lookupvar('foreman::thin_start_port').to_i + i}/#{scope.lookupvar('foreman::deployment_url')}" %>
   <%- end -%>
@@ -6,7 +6,7 @@
 
 <Location /foreman>
   RequestHeader set X_FORWARDED_PROTO 'https' env=HTTPS
-  ProxyPass balancer://foremanthinservers
-  ProxyPassReverse balancer://foremanthinservers
+  ProxyPass balancer://foreman-thin-servers
+  ProxyPassReverse balancer://foreman-thin-servers
 </Location>
 


### PR DESCRIPTION
And redirect other http calls on Foreman to https version.
