### PR TITLE
Configurable SSO based on deployment mode

### DIFF
--- a/modules/katello/manifests/params.pp
+++ b/modules/katello/manifests/params.pp
@@ -36,6 +36,15 @@ class katello::params {
       }
   }
 
+  case $deployment {
+    'katello': {
+      $use_sso = true
+    }
+    'headpin': {
+      $use_sso = false
+    }
+  }
+
   # HTTP Proxy settings (currently used by pulp)
   $proxy_url = katello_config_value('proxy_url')
   $proxy_port = katello_config_value('proxy_port')

--- a/modules/katello/templates/etc/katello/katello.yml.erb
+++ b/modules/katello/templates/etc/katello/katello.yml.erb
@@ -53,7 +53,7 @@ common:
 
   # authentication
   sso:
-    enable: true
+    enable: <%= scope.lookupvar("katello::params::use_sso") %>
     provider_url: https://<%= scope.lookupvar('fqdn') -%>/signo
     logout_path: /logout
 


### PR DESCRIPTION
For headpin we should not enable Signo. This should solve https://github.com/Katello/katello/issues/2164
