### PR TITLE
Run token generating under root

### DIFF
--- a/modules/foreman/manifests/config.pp
+++ b/modules/foreman/manifests/config.pp
@@ -90,7 +90,6 @@ class foreman::config {
     command     => "/usr/bin/${katello::params::scl_prefix}rake security:generate_token",
     path        => "/bin:/usr/bin",
     creates     => $foreman_token_file,
-    user        => $foreman::user,
   } ~>
 
   file {"${foreman_token_file}":


### PR DESCRIPTION
Foreman user does not have permission to write the file. We set correct
permissions immediately after.
