### PR TITLE
Use fqdn in foreman_url settings

### DIFF
--- a/lib/puppet/parser/functions/katello_subsystem_url.rb
+++ b/lib/puppet/parser/functions/katello_subsystem_url.rb
@@ -1,9 +1,10 @@
 module Puppet::Parser::Functions
   # without setting pulp url using fqdn urls to pulp repo in TDL
   # manifests are not usable
-  newfunction(:katello_pulp_url, :type => :rvalue) do |args|
+  newfunction(:katello_subsystem_url, :type => :rvalue) do |args|
     host = lookupvar("::fqdn")
     host = "localhost" if host.nil? || host.empty?
-    "https://#{host}/pulp/api/v2/".downcase
+    path = args.first
+    "https://#{host}/#{path}".downcase
   end
 end

--- a/modules/katello/manifests/params.pp
+++ b/modules/katello/manifests/params.pp
@@ -113,8 +113,8 @@ class katello::params {
 
   # Subsystems settings
   $candlepin_url = "https://localhost:8443/candlepin"
-  $pulp_url      = katello_pulp_url()
-  $foreman_url   = "https://localhost/foreman"
+  $pulp_url      = katello_subsystem_url("pulp/api/v2/")
+  $foreman_url   = katello_subsystem_url("foreman")
 
   # database reinitialization flag
   $reset_data = katello_config_value('reset_data')


### PR DESCRIPTION
It's used for crosslink: needs to have proper fqdn that can be used outside of
the system.
