### PR TITLE
Allows LDAP configuration also in Signo

### DIFF
--- a/modules/signo/manifests/init.pp
+++ b/modules/signo/manifests/init.pp
@@ -1,5 +1,6 @@
 class signo {
   include apache2
+  include signo::params
   include signo::install
   include signo::config
   include signo::service

--- a/modules/signo/manifests/params.pp
+++ b/modules/signo/manifests/params.pp
@@ -1,0 +1,7 @@
+class signo::params {
+  if ($katello::params::auth_method == "ldap"){
+    $backend = 'ldap'
+  } else {
+    $backend = 'katello'
+  }
+}

--- a/modules/signo/templates/etc/signo/sso.yml.erb
+++ b/modules/signo/templates/etc/signo/sso.yml.erb
@@ -20,30 +20,30 @@
   :backends:
 #    # these backends will be used to authenticate user (order is significant)
 #    # user is authenticated if one of backends succeed
-#    :enabled:
-#     - katello
+    :enabled:
+      - <%= scope.lookupvar('signo::params::backend') %>
     :katello:
       # on which url we should authenticate users against katello
       :url: https://<%= scope.lookupvar('fqdn') -%>/<%= scope.lookupvar('katello::params::deployment') -%>/authenticate
-#    :ldap:
-#      host: localhost
-#      port: 389
-#       ## blank or :start_tls
-#      encryption:
-#      ## baseDN for ldap auth, eg dc=redhat,dc=com
-#      base_dn: ou=People,dc=my-domain,dc=com
-#      ##baseDN for your ldap groups, eg ou=Groups,dc=redhat,dc=com
-#      group_base: ou=Groupd,dc=my-domain,dc=com
-#      ## type of server. default == posix. :active_directory, :posix, :free_ipa
-#      server_type: :posix
-#      ## domain for your users if using active directory, eg redhat.com
-#      ad_domain:
-#      ## service account for authenticating ldap calls in active directory or ipa
-#      service_user:
-#      ## service password for authenticating ldap calls in active directory or ipa
-#      service_pass:
-#      ## allow anonymous queries for AD or FreeIPA
-#      anon_queries:
+    :ldap:
+       host: <%= scope.lookupvar('katello::params::ldap_server') %>
+       port: <%= scope.lookupvar('katello::params::ldap_port') %>
+       ## blank or :start_tls
+       encryption: <%= scope.lookupvar('katello::params::ldap_encryption') %>
+       ## baseDN for ldap auth, eg dc=redhat,dc=com
+       base_dn: <%= scope.lookupvar('katello::params::ldap_users_basedn') %>
+       ##baseDN for your ldap groups, eg ou=Groups,dc=redhat,dc=com
+       group_base: <%= scope.lookupvar('katello::params::ldap_groups_basedn') %>
+       ## type of server. default == posix. :active_directory, :posix, :free_ipa
+       server_type: <%= scope.lookupvar('katello::params::ldap_server_type') %>
+       ## domain for your users if using active directory, eg redhat.com
+       ad_domain: <%= scope.lookupvar('katello::params::ldap_ad_domain') %>
+       ## service account for authenticating ldap calls in active directory or ipa
+       service_user: <%= scope.lookupvar('katello::params::ldap_service_user') %>
+       ## service password for authenticating ldap calls in active directory or ipa
+       service_pass: <%= scope.lookupvar('katello::params::ldap_service_pass') %>
+       ## allow anonymous queries for AD or FreeIPA
+       anon_queries: <%= scope.lookupvar('katello::params::ldap_anon_queries') %>
 #
 #  # here you can set length of cookies and session life, values are in hours
 #  # we want to store cookie with username for 1 year, it's just for better UX (username prefilled)


### PR DESCRIPTION
When user choose to use LDAP as authentication method in Katello, Signo
will configure itself accordingly. It will enable LDAP as the only
authentication backend.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=961395
