### PR TITLE
issue 2287 - fixing user pass install not working

### DIFF
--- a/bin/katello-configure
+++ b/bin/katello-configure
@@ -206,7 +206,8 @@ puts 'Starting Katello configuration'
 create_answer_file(result_config_path, $final_options, $default_options_order, $titles)
 
 # additional temporary file which is also used (but deleted afterwards)
-temp_config_path = create_temp_config_file($temp_options)
+temp_file = create_temp_config_file($temp_options)
+temp_config_path = temp_file.path 
 
 now = Time.now.strftime("%Y%m%d-%H%M%S")
 log_directory = log_parent_directory + '/katello-configure-' + now

--- a/lib/util/functions.rb
+++ b/lib/util/functions.rb
@@ -329,15 +329,17 @@ end
 # additional temporary file which is also used (but deleted afterwards)
 def create_temp_config_file(temp_options)
   orig_umask = File.umask(077)
-  temp_config_path = '/dev/null'
+  temp_file = nil
   Tempfile.open("katello-configure-temp") do |temp_config|
-    temp_config_path = temp_config.path
+    temp_file = temp_config
     $temp_options.each_pair do |key, value|
       temp_config.syswrite("#{key}=#{value}\n")
     end
   end
   File.umask(orig_umask)
-  return temp_config_path
+  #TempFiles are deleted upon garbage collection
+  # so the object needs to be kept track of
+  return temp_file
 end
 
 def main_puppet(puppet_cmd, nobars, default_progressbar_title, puppet_logfile_filename, puppet_logfile_aprox_size, debug_stdout, commands_by_logfiles, puppet_in)


### PR DESCRIPTION
TempFiles are deleted at garbage collection time
http://www.ruby-doc.org/stdlib-1.9.3/libdoc/tempfile/rdoc/Tempfile.html

Previously we would simply return the path, discarding
the file object, so as soon as the create_temp_config_file
function returned, the file may be deleted.  Now we keep
track of the file object through the life of katello-configure
