### PR TITLE
make katello-configure SCL compliant

### DIFF
--- a/aux/scl_check_erb
+++ b/aux/scl_check_erb
@@ -1,0 +1,6 @@
+#!/bin/bash
+for F in $*;
+do
+  echo -n "ERB check: $F... "
+  scl enable ruby193 "erb -x -T '-' '$F'" | scl enable ruby193 "ruby -c"
+done

--- a/aux/scl_check_erb
+++ b/aux/scl_check_erb
@@ -2,5 +2,5 @@
 for F in $*;
 do
   echo -n "ERB check: $F... "
-  scl enable ruby193 "erb -x -T '-' '$F'" | scl enable ruby193 "ruby -c"
+  scl enable ruby193 "erb -x -T '-' '$F'" | /usr/bin/ruby193-ruby -c 
 done

--- a/bin/katello-configure
+++ b/bin/katello-configure
@@ -28,7 +28,7 @@ $stdout.sync = true
 default_path = "#{PREFIX}/default-answer-file"
 options_format_path = "#{PREFIX}/options-format-file"
 result_config_path = "/etc/katello/katello-configure.conf"
-puppet_cmd = "puppet apply --modulepath #{PREFIX}/puppet/modules --libdir #{PREFIX}/puppet/lib -v -d"
+puppet_cmd = "/usr/bin/ruby193-puppet apply --modulepath #{PREFIX}/puppet/modules --libdir #{PREFIX}/puppet/lib -v -d"
 log_parent_directory = '/var/log/katello'
 default_progressbar_title = 'Katello configuration'
 

--- a/bin/katello-configure
+++ b/bin/katello-configure
@@ -28,7 +28,7 @@ $stdout.sync = true
 default_path = "#{PREFIX}/default-answer-file"
 options_format_path = "#{PREFIX}/options-format-file"
 result_config_path = "/etc/katello/katello-configure.conf"
-puppet_cmd = "/usr/bin/ruby193-puppet apply --modulepath #{PREFIX}/puppet/modules --libdir #{PREFIX}/puppet/lib -v -d"
+puppet_cmd = "puppet apply --modulepath #{PREFIX}/puppet/modules --libdir #{PREFIX}/puppet/lib -v -d"
 log_parent_directory = '/var/log/katello'
 default_progressbar_title = 'Katello configuration'
 

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -91,6 +91,7 @@ rm -f upgrade-scripts/README
 #replace shebangs for SCL
 %if %{?scl:1}%{!?scl:0}
     sed -ri '1,$s|/usr/bin/rake|/usr/bin/ruby193-rake|' upgrade-scripts/*
+    sed -ri '1,$s|/usr/bin/ruby|/usr/bin/ruby193-ruby|' upgrade-scripts/* bin/* lib/util/*
     sed -ri '1,$s|puppet apply|/usr/bin/ruby193-puppet apply|' bin/katello-configure
 %endif
 

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -76,7 +76,6 @@ running katello-configure will configure the Foreman as well.
     #check syntax for all puppet scripts
     # Puppet Bug #16006 (puppet 2.7 not working without a hostname)
     find -name '*.pp' | FACTER_hostname=builder xargs -t %{scl_puppet} parser validate
-    %endif
 
     #check for puppet erb syntax errors
     %if %{?scl:1}%{!?scl:0}

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -36,8 +36,9 @@ Requires:       policycoreutils-python
 Requires:       initscripts
 Requires:       libselinux-ruby
 Requires:       %{?scl_prefix}rubygem(rake)
-Requires:       rubygem(ruby-progressbar)
-BuildRequires:  /usr/bin/pod2man /usr/bin/erb
+Requires:       %{?scl_prefix}rubygem(ruby-progressbar)
+BuildRequires:  %{?scl_prefix}ruby(abi) = 1.9.1
+BuildRequires:  /usr/bin/pod2man
 BuildRequires:  findutils puppet >= 2.6.6
 BuildRequires:  sed
 
@@ -77,7 +78,11 @@ running katello-configure will configure the Foreman as well.
     %endif
 
     #check for puppet erb syntax errors
-    find modules/ -name \*erb | xargs aux/check_erb
+    %if %{?scl:1}%{!?scl:0}
+        find modules/ -name \*erb | xargs aux/scl_check_erb
+    %else
+        find modules/ -name \*erb | xargs aux/check_erb
+    %endif 
 %endif
 
 # README is development (git) only

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -76,7 +76,7 @@ running katello-configure will configure the Foreman as well.
     #check syntax for all puppet scripts
     %if 0%{?rhel} || 0%{?fedora} < 17
     # Puppet 2.6 parseonly mode does not handle multiple files correctly
-    find -name '*.pp' | xargs -n 1 -t scl_puppet --parseonly
+    find -name '*.pp' | xargs -n 1 -t %{scl_ruby} parser validate
     %else
     # Puppet Bug #16006 (puppet 2.7 not working without a hostname)
     find -name '*.pp' | FACTER_hostname=builder xargs -t scl_puppet parser validate

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -26,7 +26,7 @@ License:        GPLv2
 URL:            http://www.katello.org
 Source0:        https://fedorahosted.org/releases/k/a/katello/%{name}-%{version}.tar.gz
 
-Requires:       puppet >= 2.6.6
+Requires:       %{?scl_prefix}puppet >= 2.6.6
 Requires:       coreutils
 Requires:       wget
 Requires:       katello-certs-tools

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -15,8 +15,10 @@
 %if "%{?scl}" == "ruby193"
     %global scl_prefix %{scl}-
     %global scl_ruby /usr/bin/ruby193-ruby
+    %global scl_puppet /usr/bin/ruby193-puppet
 %else
     %global scl_ruby /usr/bin/ruby
+    %global scl_puppet /usr/bin/puppet
 %endif
 
 Name:           katello-configure
@@ -74,10 +76,10 @@ running katello-configure will configure the Foreman as well.
     #check syntax for all puppet scripts
     %if 0%{?rhel} || 0%{?fedora} < 17
     # Puppet 2.6 parseonly mode does not handle multiple files correctly
-    find -name '*.pp' | xargs -n 1 -t puppet --parseonly
+    find -name '*.pp' | xargs -n 1 -t scl_puppet --parseonly
     %else
     # Puppet Bug #16006 (puppet 2.7 not working without a hostname)
-    find -name '*.pp' | FACTER_hostname=builder xargs -t puppet parser validate
+    find -name '*.pp' | FACTER_hostname=builder xargs -t scl_puppet parser validate
     %endif
 
     #check for puppet erb syntax errors
@@ -94,6 +96,7 @@ rm -f upgrade-scripts/README
 #replace shebangs for SCL
 %if %{?scl:1}%{!?scl:0}
     sed -ri '1,$s|/usr/bin/rake|/usr/bin/ruby193-rake|' upgrade-scripts/*
+    sed -ri '1,$s|puppet apply|/usr/bin/ruby193-puppet apply|' bin/katello-configure
 %endif
 
 #build katello-configure man page

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -39,7 +39,7 @@ Requires:       %{?scl_prefix}rubygem(rake)
 Requires:       %{?scl_prefix}rubygem(ruby-progressbar)
 BuildRequires:  %{?scl_prefix}ruby(abi) = 1.9.1
 BuildRequires:  /usr/bin/pod2man
-BuildRequires:  findutils puppet >= 2.6.6
+BuildRequires:  findutils %{?scl_prefix}puppet >= 2.6.6
 BuildRequires:  sed
 
 BuildArch: noarch

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -74,12 +74,8 @@ running katello-configure will configure the Foreman as well.
     %{scl_ruby} -c bin/* lib/puppet/parser/functions/*rb
 
     #check syntax for all puppet scripts
-    %if 0%{?rhel} || 0%{?fedora} < 17
-    # Puppet 2.6 parseonly mode does not handle multiple files correctly
-    find -name '*.pp' | xargs -n 1 -t %{scl_ruby} parser validate
-    %else
     # Puppet Bug #16006 (puppet 2.7 not working without a hostname)
-    find -name '*.pp' | FACTER_hostname=builder xargs -t scl_puppet parser validate
+    find -name '*.pp' | FACTER_hostname=builder xargs -t %{scl_puppet} parser validate
     %endif
 
     #check for puppet erb syntax errors

--- a/katello-configure.spec
+++ b/katello-configure.spec
@@ -14,6 +14,9 @@
 %global homedir %{_datarootdir}/katello/install
 %if "%{?scl}" == "ruby193"
     %global scl_prefix %{scl}-
+    %global scl_ruby /usr/bin/ruby193-ruby
+%else
+    %global scl_ruby /usr/bin/ruby
 %endif
 
 Name:           katello-configure
@@ -66,7 +69,7 @@ running katello-configure will configure the Foreman as well.
 %build
 %if ! 0%{?fastbuild:1}
     #check syntax of main configure script and libs
-    ruby -c bin/* lib/puppet/parser/functions/*rb
+    %{scl_ruby} -c bin/* lib/puppet/parser/functions/*rb
 
     #check syntax for all puppet scripts
     %if 0%{?rhel} || 0%{?fedora} < 17


### PR DESCRIPTION
making katello-configure SCL compliant, had to add the duplicate script since there was no simple way of making that erb script use SCL or not.  too many quotes and escapes 
