### PR TITLE
scl_root - add parameter and use in puppet template

### DIFF
--- a/modules/foreman/templates/settings.yaml.erb
+++ b/modules/foreman/templates/settings.yaml.erb
@@ -3,7 +3,7 @@
 #if none specified, plain "puppet" will be used.
 #:puppet_server: puppet
 :unattended: <%= scope.lookupvar("foreman::unattended") %>
-:puppetconfdir: /etc/puppet/puppet.conf
+:puppetconfdir: <%= scope.lookupvar("katello::params::scl_root") %>/etc/puppet/puppet.conf
 :login: <%= scope.lookupvar("foreman::authentication") %>
 :require_ssl: <%= scope.lookupvar("foreman::ssl") %>
 :organizations_enabled: true

--- a/modules/katello/manifests/params.pp
+++ b/modules/katello/manifests/params.pp
@@ -2,8 +2,10 @@ class katello::params {
 
   if ($operatingsystem == "RedHat" or $operatingsystem == "CentOS"){
     $scl_prefix = 'ruby193-'
+    $scl_root = '/opt/rh/ruby193/root'
   } else {
     $scl_prefix = ''
+    $scl_root = ''
   }
 
   # First User and Org settings


### PR DESCRIPTION
Since we'll support installing with puppet based on SCL, we
need to have the puppet.conf in the foreman config point
to the location within the SCL path.  This adds a parameter
that we can use elsewhere, if needed.
