### PR TITLE
Set HOME=${foreman::app_root} for foreman Rails actions

### DIFF
--- a/modules/foreman/manifests/config.pp
+++ b/modules/foreman/manifests/config.pp
@@ -119,7 +119,7 @@ class foreman::config {
 
   exec {"foreman_migrate_db":
     cwd         => $foreman::app_root,
-    environment => ["RAILS_ENV=${foreman::environment}", "BUNDLER_EXT_NOSTRICT=1"],
+    environment => ["RAILS_ENV=${foreman::environment}", "BUNDLER_EXT_NOSTRICT=1", "HOME=${foreman::app_root}"],
     command     => "/usr/bin/${katello::params::scl_prefix}rake db:migrate --trace --verbose && touch /var/lib/foreman/foreman_db_migrate_done",
     path        => "/sbin:/usr/sbin:/bin:/usr/bin",
     creates     => "/var/lib/foreman/foreman_db_migrate_done",
@@ -133,7 +133,7 @@ class foreman::config {
   } ~>
 
   exec {"foreman_config":
-   environment => ['HOME=/root'],
+   environment => ["HOME=${foreman::app_root}"],
    cwd     => $foreman::app_root,
    command => $foreman_config_cmd,
    unless  => "$foreman_config_cmd --dry-run",


### PR DESCRIPTION
We run the actions as foreman, so setting home to root is not the best way.

Addresses the Puppet expand issue.
