### PR TITLE
972230 - decreasing pulp concurrency count

### DIFF
--- a/modules/pulp/templates/etc/pulp/server.conf.erb
+++ b/modules/pulp/templates/etc/pulp/server.conf.erb
@@ -260,7 +260,7 @@ debugging_mode: false
 # sync_weight: (integer) concurrency "weight" of a repository sync task
 
 [tasks]
-concurrency_threshold = <%= 2*processorcount.to_i + 1 %>
+concurrency_threshold = <%= processorcount.to_i + 1 %>
 dispatch_interval: 0.5
 archived_call_lifetime: 48
 consumer_content_weight: 0


### PR DESCRIPTION
To help with thrashing and memory usage while lots of tasks are
occuring. 
