### PR TITLE
973630 - redirect to https only if the path begins with '/katello'

### DIFF
--- a/modules/katello/templates/etc/httpd/conf.d/katello.conf.erb
+++ b/modules/katello/templates/etc/httpd/conf.d/katello.conf.erb
@@ -31,7 +31,7 @@ NameVirtualHost *:80
 <VirtualHost *:80>
   RewriteEngine On
   RewriteCond %{HTTPS} off
-  RewriteRule /<%= scope.lookupvar("katello::params::deployment_url") %>(.*)$ https://%{HTTP_HOST}%{REQUEST_URI}
+  RewriteRule ^/<%= scope.lookupvar("katello::params::deployment_url") %>(.*)$ https://%{HTTP_HOST}%{REQUEST_URI}
   <%- if scope.lookupvar("katello::params::deployment") == 'katello' -%>
   Include /etc/pulp/vhosts80/*.conf
   <%- end -%>


### PR DESCRIPTION
Otherwise, also paths with '/katello' inside were redirected to https, which
caused problems with provisioning.
