### PR TITLE
975925-deployment - use correct var in candlepin.conf

### DIFF
--- a/modules/candlepin/manifests/params.pp
+++ b/modules/candlepin/manifests/params.pp
@@ -21,8 +21,8 @@ class candlepin::params {
   # database reinitialization flag
   $reset_data = katello_config_value('reset_data')
 
-  $weburl = "https://${::fqdn}/${::katello::params::deployment}/distributors?uuid="
-  $apiurl = "https://${::fqdn}/${::katello::params::deployment}/api/distributors/"
+  $weburl = "https://${::fqdn}/${::katello::params::deployment_url}/distributors?uuid="
+  $apiurl = "https://${::fqdn}/${::katello::params::deployment_url}/api/distributors/"
 
   case $katello::params::deployment {
     'headpin' : {


### PR DESCRIPTION
This properly handles if --deployment=sam (previously would always use /headpin in url, even in SAM mode)
