### PR TITLE
Fixed qpidd config templates issue for RHEL 6

### DIFF
--- a/modules/qpid/manifests/config.pp
+++ b/modules/qpid/manifests/config.pp
@@ -12,9 +12,6 @@ class qpid::config {
   }
   else {
     $mechanism_option = 'cluster-mechanism'
-    package {"qpid-cpp-server-cluster":
-      ensure => installed,
-    }
   }
 
   file { "/etc/qpidd.conf":
@@ -22,5 +19,5 @@ class qpid::config {
     before => [Class["qpid::service"]],
     notify => Service["qpidd"]
   }
-  
+
 }

--- a/modules/qpid/templates/etc/qpidd.conf.erb
+++ b/modules/qpid/templates/etc/qpidd.conf.erb
@@ -12,21 +12,21 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0 
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, 
-# software distributed under the License is distributed on an 
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-# KIND, either express or implied. See the License for the 
-# specific language governing permissions and limitations 
-# under the License. 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
-# Configuration file for qpidd. Entries are of the form: 
-# name=value 
+# Configuration file for qpidd. Entries are of the form:
+# name=value
 #
-# (Note: no spaces on either side of '='). Using default settings: 
-# "qpidd --help" or "man qpidd" for more details. 
-<%= @mechanism_option %>=DIGEST-MD5 ANONYMOUS
+# (Note: no spaces on either side of '='). Using default settings:
+# "qpidd --help" or "man qpidd" for more details.
+<%= @mechanism_option %>=ANONYMOUS
 log-enable=error+
 
 auth=no


### PR DESCRIPTION
RHEL6 uses the older version of qpidd, so left that untouched.
Removed the need to install  qpid-cpp-server-cluster for RHEL6.
