### PR TITLE
Updated qpid package lists to install for f19 & 18

### DIFF
--- a/modules/qpid/manifests/install.pp
+++ b/modules/qpid/manifests/install.pp
@@ -1,6 +1,13 @@
 class qpid::install {
 
-  package {["qpid-cpp-server","qpid-cpp-client","qpid-cpp-client-ssl","qpid-cpp-server-ssl"]:
+  if $::operatingsystem == 'Fedora' {
+    $packages_to_install = ["qpid-cpp-server","qpid-cpp-client"]
+  }
+  else {
+    $packages_to_install = ["qpid-cpp-server","qpid-cpp-client","qpid-cpp-client-ssl","qpid-cpp-server-ssl"]
+  }
+
+  package {$packages_to_install:
     ensure => "installed",
     before => Service["qpidd"]
   } 

--- a/modules/qpid/manifests/service.pp
+++ b/modules/qpid/manifests/service.pp
@@ -1,4 +1,11 @@
 class qpid::service {
+  if $::operatingsystem == 'Fedora' {
+    $packages_qpid_server = "qpid-cpp-server"
+  }
+  else {
+    $packages_qpid_server = "qpid-cpp-server-ssl"
+  }
+
   service {"qpidd":
     ensure => running,
     enable => true,
@@ -6,7 +13,7 @@ class qpid::service {
     hasrestart => true,
     require => [
       Class["qpid::config"],
-      Package["qpid-cpp-server-ssl"],
+      Package[$packages_qpid_server],
       Class["certs::config"]
     ]
   }


### PR DESCRIPTION
In Fedora 18 and 19 qpidd-cpp-server-ssl and qpid-cpp-client-ssl have been obseleted
by qpid-cpp-server and qpid-cpp-client. So changing the puppet installer code to
deal with that
