### PR TITLE
Update server.xml.erb

### DIFF
--- a/modules/candlepin/templates/etc/tomcat/server.xml.erb
+++ b/modules/candlepin/templates/etc/tomcat/server.xml.erb
@@ -28,7 +28,7 @@
 <Server port="8005" shutdown="SHUTDOWN">
 
   <!--APR library loader. Documentation at /docs/apr.html -->
-  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" /> -->
   <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
   <Listener className="org.apache.catalina.core.JasperListener" />
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->


### PR DESCRIPTION
Since you are using keystore, APR is conflicting with keystore. If you don't have the APR based Apache Tomcat Native library installed, you won't notice it's breaking tomcat. APR required SSL certs definition.